### PR TITLE
Support disabling file-related functions in stdio

### DIFF
--- a/ckb/build.sh
+++ b/ckb/build.sh
@@ -2,8 +2,12 @@
 set -ex
 
 CLANG="${CLANG:-clang-18}"
-BASE_CFLAGS="${BASE_CFLAGS:---target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -DPAGE_SIZE=4096 -DDISABLE_STD_FLIE -O3}"
+BASE_CFLAGS="${BASE_CFLAGS:---target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -DPAGE_SIZE=4096  -O3}"
 N_PROC="${N_PROC:-$(nproc)}"
+
+if [[ ${DISABLE_STD_FILE} == "true" ]]; then
+  BASE_CFLAGS="${BASE_CFLAGS} -DDISABLE_STD_FLIE"
+fi
 
 mkdir -p release
 CC="${CLANG}" CFLAGS="${BASE_CFLAGS}" \

--- a/ckb/build.sh
+++ b/ckb/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 CLANG="${CLANG:-clang-18}"
-BASE_CFLAGS="${BASE_CFLAGS:---target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -DPAGE_SIZE=4096 -O3}"
+BASE_CFLAGS="${BASE_CFLAGS:---target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -DPAGE_SIZE=4096 -DDISABLE_STD_FLIE -O3}"
 N_PROC="${N_PROC:-$(nproc)}"
 
 mkdir -p release

--- a/src/stdio/clearerr.c
+++ b/src/stdio/clearerr.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 void clearerr(FILE *f)
@@ -8,3 +9,4 @@ void clearerr(FILE *f)
 }
 
 weak_alias(clearerr, clearerr_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fclose.c
+++ b/src/stdio/fclose.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <stdlib.h>
 
@@ -36,3 +37,4 @@ int fclose(FILE *f)
 
 	return r;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/feof.c
+++ b/src/stdio/feof.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 #undef feof
@@ -12,3 +13,4 @@ int feof(FILE *f)
 
 weak_alias(feof, feof_unlocked);
 weak_alias(feof, _IO_feof_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/ferror.c
+++ b/src/stdio/ferror.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 #undef ferror
@@ -12,3 +13,4 @@ int ferror(FILE *f)
 
 weak_alias(ferror, ferror_unlocked);
 weak_alias(ferror, _IO_ferror_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fflush.c
+++ b/src/stdio/fflush.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 /* stdout.c will override this if linked */
@@ -45,3 +46,4 @@ int fflush(FILE *f)
 }
 
 weak_alias(fflush, fflush_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgetc.c
+++ b/src/stdio/fgetc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include "getc.h"
 
@@ -5,3 +6,4 @@ int fgetc(FILE *f)
 {
 	return do_getc(f);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgetln.c
+++ b/src/stdio/fgetln.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #define _GNU_SOURCE
 #include "stdio_impl.h"
 #include <string.h>
@@ -19,3 +20,4 @@ char *fgetln(FILE *f, size_t *plen)
 	FUNLOCK(f);
 	return ret;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgetpos.c
+++ b/src/stdio/fgetpos.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 int fgetpos(FILE *restrict f, fpos_t *restrict pos)
@@ -7,3 +8,4 @@ int fgetpos(FILE *restrict f, fpos_t *restrict pos)
 	*(long long *)pos = off;
 	return 0;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgets.c
+++ b/src/stdio/fgets.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <string.h>
 
@@ -47,3 +48,4 @@ char *fgets(char *restrict s, int n, FILE *restrict f)
 }
 
 weak_alias(fgets, fgets_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgetwc.c
+++ b/src/stdio/fgetwc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "locale_impl.h"
 #include <wchar.h>
@@ -66,3 +67,4 @@ wint_t fgetwc(FILE *f)
 
 weak_alias(__fgetwc_unlocked, fgetwc_unlocked);
 weak_alias(__fgetwc_unlocked, getwc_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fgetws.c
+++ b/src/stdio/fgetws.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <wchar.h>
 
@@ -26,3 +27,4 @@ wchar_t *fgetws(wchar_t *restrict s, int n, FILE *restrict f)
 }
 
 weak_alias(fgetws, fgetws_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fileno.c
+++ b/src/stdio/fileno.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <errno.h>
 
@@ -14,3 +15,4 @@ int fileno(FILE *f)
 }
 
 weak_alias(fileno, fileno_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/flockfile.c
+++ b/src/stdio/flockfile.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "pthread_impl.h"
 
@@ -7,3 +8,4 @@ void flockfile(FILE *f)
 	__lockfile(f);
 	__register_locked_file(f, __pthread_self());
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fmemopen.c
+++ b/src/stdio/fmemopen.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <errno.h>
 #include <string.h>
@@ -125,3 +126,4 @@ FILE *fmemopen(void *restrict buf, size_t size, const char *restrict mode)
 
 	return __ofl_add(&f->f);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fopen.c
+++ b/src/stdio/fopen.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <fcntl.h>
 #include <string.h>
@@ -29,3 +30,4 @@ FILE *fopen(const char *restrict filename, const char *restrict mode)
 	__syscall(SYS_close, fd);
 	return 0;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fopencookie.c
+++ b/src/stdio/fopencookie.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #define _GNU_SOURCE
 #include "stdio_impl.h"
 #include <stdlib.h>
@@ -133,3 +134,4 @@ FILE *fopencookie(void *cookie, const char *mode, cookie_io_functions_t iofuncs)
 	/* Add new FILE to open file list */
 	return __ofl_add(&f->f);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fputc.c
+++ b/src/stdio/fputc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include "putc.h"
 
@@ -5,3 +6,4 @@ int fputc(int c, FILE *f)
 {
 	return do_putc(c, f);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fputs.c
+++ b/src/stdio/fputs.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <string.h>
 
@@ -8,3 +9,4 @@ int fputs(const char *restrict s, FILE *restrict f)
 }
 
 weak_alias(fputs, fputs_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fputwc.c
+++ b/src/stdio/fputwc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "locale_impl.h"
 #include <wchar.h>
@@ -38,3 +39,4 @@ wint_t fputwc(wchar_t c, FILE *f)
 
 weak_alias(__fputwc_unlocked, fputwc_unlocked);
 weak_alias(__fputwc_unlocked, putwc_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fputws.c
+++ b/src/stdio/fputws.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "locale_impl.h"
 #include <wchar.h>
@@ -27,3 +28,4 @@ int fputws(const wchar_t *restrict ws, FILE *restrict f)
 }
 
 weak_alias(fputws, fputws_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fread.c
+++ b/src/stdio/fread.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <string.h>
 
@@ -36,3 +37,4 @@ size_t fread(void *restrict destv, size_t size, size_t nmemb, FILE *restrict f)
 }
 
 weak_alias(fread, fread_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/freopen.c
+++ b/src/stdio/freopen.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <fcntl.h>
 #include <unistd.h>
@@ -51,3 +52,4 @@ fail:
 	fclose(f);
 	return NULL;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fscanf.c
+++ b/src/stdio/fscanf.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -12,3 +13,4 @@ int fscanf(FILE *restrict f, const char *restrict fmt, ...)
 }
 
 weak_alias(fscanf, __isoc99_fscanf);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fseek.c
+++ b/src/stdio/fseek.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <errno.h>
 
@@ -46,3 +47,4 @@ int fseek(FILE *f, long off, int whence)
 }
 
 weak_alias(__fseeko, fseeko);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fsetpos.c
+++ b/src/stdio/fsetpos.c
@@ -1,6 +1,8 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 int fsetpos(FILE *f, const fpos_t *pos)
 {
 	return __fseeko(f, *(const long long *)pos, SEEK_SET);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/ftell.c
+++ b/src/stdio/ftell.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include <limits.h>
 #include <errno.h>
@@ -37,3 +38,4 @@ long ftell(FILE *f)
 }
 
 weak_alias(__ftello, ftello);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/ftrylockfile.c
+++ b/src/stdio/ftrylockfile.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "pthread_impl.h"
 #include <limits.h>
@@ -44,3 +45,4 @@ int ftrylockfile(FILE *f)
 	__register_locked_file(f, self);
 	return 0;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/funlockfile.c
+++ b/src/stdio/funlockfile.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 #include "pthread_impl.h"
 
@@ -11,3 +12,4 @@ void funlockfile(FILE *f)
 		f->lockcount--;
 	}
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fwide.c
+++ b/src/stdio/fwide.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <wchar.h>
 #include "stdio_impl.h"
 #include "locale_impl.h"
@@ -14,3 +15,4 @@ int fwide(FILE *f, int mode)
 	FUNLOCK(f);
 	return mode;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fwprintf.c
+++ b/src/stdio/fwprintf.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include <stdarg.h>
 #include <wchar.h>
@@ -11,3 +12,4 @@ int fwprintf(FILE *restrict f, const wchar_t *restrict fmt, ...)
 	va_end(ap);
 	return ret;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fwrite.c
+++ b/src/stdio/fwrite.c
@@ -25,6 +25,7 @@ size_t __fwritex(const unsigned char *restrict s, size_t l, FILE *restrict f)
 	return l+i;
 }
 
+#ifndef DISABLE_STD_FLIE
 size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f)
 {
 	size_t k, l = size*nmemb;
@@ -36,3 +37,4 @@ size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restric
 }
 
 weak_alias(fwrite, fwrite_unlocked);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/fwscanf.c
+++ b/src/stdio/fwscanf.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include <stdarg.h>
 #include <wchar.h>
@@ -13,3 +14,4 @@ int fwscanf(FILE *restrict f, const wchar_t *restrict fmt, ...)
 }
 
 weak_alias(fwscanf,__isoc99_fwscanf);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/getc.c
+++ b/src/stdio/getc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include "getc.h"
 
@@ -7,3 +8,4 @@ int getc(FILE *f)
 }
 
 weak_alias(getc, _IO_getc);
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/getline.c
+++ b/src/stdio/getline.c
@@ -1,6 +1,8 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 
 ssize_t getline(char **restrict s, size_t *restrict n, FILE *restrict f)
 {
 	return getdelim(s, n, '\n', f);
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/setvbuf.c
+++ b/src/stdio/setvbuf.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 /* The behavior of this function is undefined except when it is the first
@@ -27,3 +28,4 @@ int setvbuf(FILE *restrict f, char *restrict buf, int type, size_t size)
 
 	return 0;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/tmpfile.c
+++ b/src/stdio/tmpfile.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -27,3 +28,4 @@ FILE *tmpfile(void)
 	}
 	return 0;
 }
+#endif // DISABLE_STD_FLIE

--- a/src/stdio/ungetc.c
+++ b/src/stdio/ungetc.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_STD_FLIE
 #include "stdio_impl.h"
 
 int ungetc(int c, FILE *f)
@@ -18,3 +19,4 @@ int ungetc(int c, FILE *f)
 	FUNLOCK(f);
 	return (unsigned char)c;
 }
+#endif // DISABLE_STD_FLIE


### PR DESCRIPTION
When the environment variable `DISABLE_STD_FILE=true`, the file-related implementation will not be compiled. At this time, developers can implement related functions by themselves.